### PR TITLE
Set max bytes to read on the telnet client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "graze/telnet-client": "^2.2.2",
+        "graze/telnet-client": "^2.3.0",
         "graze/xml-utils": "^1.1.0"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -24,6 +24,10 @@ class Client implements ClientInterface
     public function __construct(TelnetClientInterface $telnetClient)
     {
         $this->telnetClient = $telnetClient;
+
+        // Set a limit to the number of bytes to read per request, this should hopefully prevent infinite loops if the
+        // prompt is never returned. 1000 bytes should be plenty.
+        $this->telnetClient->setMaxBytesRead(1000);
     }
 
     /**

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -22,6 +22,8 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $timeout = 1.2;
 
         $telnetClient = Mockery::mock(TelnetClientInterface::class);
+        $telnetClient->shouldReceive('setMaxBytesRead');
+
         $client = new Client($telnetClient);
 
         // Connecting without timeout
@@ -61,6 +63,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $telnetResponse = Mockery::mock(TelnetResponseInterface::class);
 
         $telnetClient = Mockery::mock(TelnetClientInterface::class);
+        $telnetClient->shouldReceive('setMaxBytesRead');
         $telnetClient->shouldReceive('execute')
             ->with($request->getXml())
             ->andReturn($telnetResponse);


### PR DESCRIPTION
Set max bytes to read on the telnet client to try and prevent timeouts.